### PR TITLE
Whitespace fix

### DIFF
--- a/src/scss/media.scss
+++ b/src/scss/media.scss
@@ -1,3 +1,4 @@
 img {
 	width: 100%;
+	vertical-align: middle;
 }


### PR DESCRIPTION
Setting `vertical-align` removes the whitespace that appears under `img` elements when they are dropped into a page as-is.