### PR TITLE
Replace protocol in link to Google fonts with HTTPS

### DIFF
--- a/src/scss/type.scss
+++ b/src/scss/type.scss
@@ -1,6 +1,6 @@
 @import './_imports/_variables';
 
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,300,500,700|Gentium+Book+Basic:400,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,300,500,700|Gentium+Book+Basic:400,700);
 
 div, p, h1, h2, h3, h4, h5, h6, a, input, label, header, aside, menu, body {
 	font-family: $sans;


### PR DESCRIPTION
The link in type.scss-file was using http,
and not https.
This would result in a "Mixed content"-error
on pages with SSL/TLS enabled.