### PR TITLE
Remove :valid CSS pseudo-class from form elements

### DIFF
--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -20,7 +20,7 @@ input {
 	  background-size: 200px 100%;
 	  background-repeat: no-repeat;
 	  color: darken($primary, 20%);
-	  &:focus, &:valid {
+	  &:focus {
 	    box-shadow: none;
 	    outline: none;
 	    background-position: 0 0;


### PR DESCRIPTION
I might be mistaken here, but it seem if the `input` element doesn't have `required` attribute the element would show as if it has focus.  
I believe this is because the element is valid, since it doesn't have any type setting for validation, and so the selector matches.  
I'm not sure what the selector was for originally, and hope simply removing it won't cause any issues.
